### PR TITLE
Password recovery, custom JWT user payload and original vapor-forms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
         .Package(url: "https://github.com/vapor/mysql-provider.git", majorVersion: 1, minor: 1),
         .Package(url: "https://github.com/nodes-vapor/sugar.git", majorVersion: 1, minor: 0),
         .Package(url: "https://github.com/siemensikkema/vapor-jwt.git", majorVersion: 0, minor: 6),
-        .Package(url: "https://github.com/Skyback/vapor-forms.git", majorVersion:0, minor: 3),
+        .Package(url: "https://github.com/bygri/vapor-forms.git", majorVersion:0, minor: 3),
+        .Package(url: "https://github.com/nodes-vapor/flash.git", majorVersion: 0),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,6 @@ let package = Package(
         .Package(url: "https://github.com/nodes-vapor/sugar.git", majorVersion: 1, minor: 0),
         .Package(url: "https://github.com/siemensikkema/vapor-jwt.git", majorVersion: 0, minor: 6),
         .Package(url: "https://github.com/bygri/vapor-forms.git", majorVersion:0, minor: 3),
-        .Package(url: "https://github.com/nodes-vapor/flash.git", majorVersion: 0),
+        .Package(url: "https://github.com/nodes-vapor/flash.git", majorVersion: 0, minor: 1),
     ]
 )

--- a/Sources/JWTKeychain/Controllers/API/UserController.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserController.swift
@@ -112,7 +112,7 @@ open class UserController: UserControllerType {
         let jwt = try JWT(token: token)
 
         guard
-            let userId = jwt.payload["id"]?.string,
+            let userId = jwt.payload["user"]?.object?["id"]?.int,
             let _ = try User.query().filter("id", userId).first() else {
             throw Abort.notFound
         }
@@ -145,7 +145,7 @@ open class UserController: UserControllerType {
         // Validate token
         if try !self.configuration.validateToken(token: token) {
             return Response(redirect: "/api/v1/users/reset-password/form")
-                .flash(.error, "Invalid token")
+                .flash(.error, "Token is invalid")
         }
 
         let jwt = try JWT(token: token)
@@ -155,7 +155,7 @@ open class UserController: UserControllerType {
             let userPasswordHash = jwt.payload["password"]?.string,
             var user = try User.query().filter("id", userId).first() else {
                 return Response(redirect: "/api/v1/users/reset-password/form")
-                    .flash(.error, "Invalid token")
+                    .flash(.error, "Token is invalid")
         }
 
         if user.email != email {
@@ -165,7 +165,7 @@ open class UserController: UserControllerType {
 
         if user.password != userPasswordHash {
             return Response(redirect: "/api/v1/users/reset-password/form")
-                .flash(.error, "Password was already changed. Cannot use same token.")
+                .flash(.error, "Password already changed. Cannot use the same token again.")
         }
 
         if password != passwordConfirmation {
@@ -177,8 +177,6 @@ open class UserController: UserControllerType {
         try user.save()
 
         return Response(redirect: "/api/v1/users/reset-password/form")
-            .flash(.success, "Password reset complete. You can close this page now.")
-
-
+            .flash(.success, "Password changed. You can close this page now.")
     }
 }

--- a/Sources/JWTKeychain/Controllers/API/UserController.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserController.swift
@@ -152,7 +152,7 @@ open class UserController: UserControllerType {
 
         guard
             let userId = jwt.payload["user"]?.object?["id"]?.int,
-            let userPasswordHash = jwt.payload["password"]?.string,
+            let userPasswordHash = jwt.payload["user"]?.object?["password"]?.string,
             var user = try User.query().filter("id", userId).first() else {
                 return Response(redirect: "/api/v1/users/reset-password/form")
                     .flash(.error, "Token is invalid")

--- a/Sources/JWTKeychain/Controllers/API/UserController.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserController.swift
@@ -8,7 +8,7 @@ import TurnstileWeb
 import VaporForms
 
 /// Controller for user api requests
-open class UsersController {
+open class UserController: UserControllerType {
     
     private let configuration: ConfigurationType
 

--- a/Sources/JWTKeychain/Controllers/API/UserController.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserController.swift
@@ -151,7 +151,7 @@ open class UserController: UserControllerType {
         let jwt = try JWT(token: token)
 
         guard
-            let userId = jwt.payload["id"]?.string,
+            let userId = jwt.payload["user"]?.object?["id"]?.int,
             let userPasswordHash = jwt.payload["password"]?.string,
             var user = try User.query().filter("id", userId).first() else {
                 return Response(redirect: "/api/v1/users/reset-password/form")

--- a/Sources/JWTKeychain/Controllers/API/UserControllerType.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserControllerType.swift
@@ -44,4 +44,24 @@ public protocol UserControllerType {
     /// - Returns: JSON response with User data.
     /// - Throws: on no user found.
     func me(request: Request) throws -> ResponseRepresentable
+
+    /// Requests a reset of password for the given email.
+    ///
+    /// - Parameter request: current request.
+    /// - Returns: success or failure message
+    func resetPasswordEmail(request: Request) -> ResponseRepresentable
+
+    /// Shows the form where the user can reset the password
+    ///
+    /// - Parameter request: current request
+    /// - Returns: view
+    func resetPasswordForm(request: Request, token: String) throws -> View
+
+    /// Validates the reset request and actually changes the password
+    ///
+    /// - Parameter request: current request
+    /// - Returns: success or error response
+    /// - Throws: if something goes wrong
+    func resetPasswordChange(request: Request) throws -> Response
+
 }

--- a/Sources/JWTKeychain/Controllers/API/UserControllerType.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserControllerType.swift
@@ -3,12 +3,13 @@ import HTTP
 
 /// Defines basic authorization functionality.
 public protocol UserControllerType {
+
     /// Initializes the UsersController with a JWT configuration.
     ///
     /// - Parameters:
     /// configuration : the JWT configuration to be used to generate user tokens.
     /// drop : the Droplet instance 
-    init(configuration: ConfigurationType, drop: Droplet)
+    init(configuration: ConfigurationType, drop: Droplet, mailer: MailerType)
 
     /// Registers a user on the DB.
     ///
@@ -49,7 +50,7 @@ public protocol UserControllerType {
     ///
     /// - Parameter request: current request.
     /// - Returns: success or failure message
-    func resetPasswordEmail(request: Request) -> ResponseRepresentable
+    func resetPasswordEmail(request: Request) throws -> ResponseRepresentable
 
     /// Shows the form where the user can reset the password
     ///

--- a/Sources/JWTKeychain/Controllers/API/UserControllerType.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserControllerType.swift
@@ -7,7 +7,8 @@ public protocol UserControllerType {
     ///
     /// - Parameters:
     /// configuration : the JWT configuration to be used to generate user tokens.
-    init(configuration: ConfigurationType)
+    /// drop : the Droplet instance 
+    init(configuration: ConfigurationType, drop: Droplet)
 
     /// Registers a user on the DB.
     ///

--- a/Sources/JWTKeychain/Controllers/Api/UsersController.swift
+++ b/Sources/JWTKeychain/Controllers/Api/UsersController.swift
@@ -14,12 +14,15 @@ open class UsersController {
     
     private let configuration: ConfigurationType
 
+    private let drop: Droplet
+
     /// Initializes the UsersController with a JWT configuration
     ///
     /// - Parameters:
     /// configuration : the JWT configuration to be used to generate user tokens
-    public init(configuration: ConfigurationType) {
+    public init(configuration: ConfigurationType, drop: Droplet) {
         self.configuration = configuration
+        self.drop = drop
     }
 
     /// Registers a user on the DB
@@ -136,10 +139,10 @@ open class UsersController {
             }
 
             // Make a token
-            var token = try self.configuration.generateToken(userId: user.id!)
+            let token = try self.configuration.generateToken(userId: user.id!)
 
             // Send mail
-            try Mailer.sendResetPasswordMail(drop: drop, user: backendUser, token: token)
+            try Mailer.sendResetPasswordMail(drop: self.drop, user: user, token: token)
             
             return JSON(["success": "Instructions were sent to the provided email"])
         } catch {

--- a/Sources/JWTKeychain/Controllers/Frontend/FrontendResetPasswordController.swift
+++ b/Sources/JWTKeychain/Controllers/Frontend/FrontendResetPasswordController.swift
@@ -1,0 +1,99 @@
+import Vapor
+import Auth
+import Foundation
+import HTTP
+import Turnstile
+import TurnstileCrypto
+import TurnstileWeb
+import VaporForms
+import VaporJWT
+import Flash
+
+/// Controller for reset password requests
+open class FrontendResetPasswordController: FrontendResetPasswordControllerType {
+
+    public let configuration: ConfigurationType
+
+    private let drop: Droplet
+
+    required public init(drop: Droplet, configuration: ConfigurationType) {
+        self.configuration = configuration
+        self.drop = drop
+    }
+
+    open func resetPasswordForm(request: Request, token: String) throws -> View {
+
+        // Validate token
+        if try !self.configuration.validateToken(token: token) {
+            throw Abort.notFound
+        }
+
+        let jwt = try JWT(token: token)
+
+        guard
+            let userId = jwt.payload["user"]?.object?["id"]?.int,
+            let _ = try User.query().filter("id", userId).first() else {
+                throw Abort.notFound
+        }
+
+        return try drop.view.make("ResetPassword/form", ["token": token])
+    }
+
+    open func resetPasswordChange(request: Request) throws -> Response {
+
+        do {
+            // Validate request
+            let requestData = try ResetPasswordRequest(validating: request.data)
+
+            // Validate token
+            if try !self.configuration.validateToken(token: requestData.token) {
+                return Response(redirect: "/api/v1/users/reset-password/form")
+                    .flash(.error, "Token is invalid")
+            }
+
+            let jwt = try JWT(token: requestData.token)
+
+            guard
+                let userId = jwt.payload["user"]?.object?["id"]?.int,
+                let userPasswordHash = jwt.payload["user"]?.object?["password"]?.string,
+                var user = try User.query().filter("id", userId).first() else {
+                    return Response(redirect: "/api/v1/users/reset-password/form")
+                        .flash(.error, "Token is invalid")
+            }
+
+            if user.email != requestData.email {
+                return Response(redirect: "/api/v1/users/reset-password/form")
+                    .flash(.error, "Email did not match")
+            }
+
+            if user.password != userPasswordHash {
+                return Response(redirect: "/api/v1/users/reset-password/form")
+                    .flash(.error, "Password already changed. Cannot use the same token again.")
+            }
+
+            if requestData.password != requestData.passwordConfirmation {
+                return Response(redirect: "/api/v1/users/reset-password/form")
+                    .flash(.error, "Password and password confirmation don't match")
+            }
+
+            user.password = BCrypt.hash(password: requestData.password)
+            try user.save()
+
+            return Response(redirect: "/api/v1/users/reset-password/form")
+                .flash(.success, "Password changed. You can close this page now.")
+
+
+        } catch FormError.validationFailed(let fieldset) {
+
+            let response = Response(redirect: "/api/v1/users/reset-password/form").flash(.error, "Data is invalid")
+            response.storage["_fieldset"] = try fieldset.makeNode()
+            
+            return response
+            
+        } catch {
+            return Response(redirect: "/api/v1/users/reset-password/form")
+                .flash(.error, "Something went wrong")
+        }
+        
+    }
+}

--- a/Sources/JWTKeychain/Controllers/Frontend/FrontendResetPasswordControllerType.swift
+++ b/Sources/JWTKeychain/Controllers/Frontend/FrontendResetPasswordControllerType.swift
@@ -1,0 +1,28 @@
+import Vapor
+import HTTP
+
+/// Defines basic authorization functionality.
+public protocol FrontendResetPasswordControllerType {
+
+    /// Initializes the FrontendResetPasswordController with the JWT 
+    /// configuration.
+    ///
+    /// - Parameters:
+    /// configuration : the JWT configuration to be used to generate user tokens.
+    /// drop : the Droplet instance
+    init(drop: Droplet, configuration: ConfigurationType)
+
+    /// Shows the form where the user can reset the password
+    ///
+    /// - Parameter request: current request
+    /// - Returns: view
+    func resetPasswordForm(request: Request, token: String) throws -> View
+
+    /// Validates the reset request and actually changes the password
+    ///
+    /// - Parameter request: current request
+    /// - Returns: success or error response
+    /// - Throws: if something goes wrong
+    func resetPasswordChange(request: Request) throws -> Response
+    
+}

--- a/Sources/JWTKeychain/Models/Users/User.swift
+++ b/Sources/JWTKeychain/Models/Users/User.swift
@@ -80,6 +80,14 @@ open class User: UserType {
             "deleted_at": self.deletedAt?.to(Date.Format.ISO8601),
         ])
     }
+
+    public func makeJWTNode() throws -> Node {
+        return try Node(node: [
+            "id": self.id,
+            "email": self.email,
+            "password": self.password,
+        ])
+    }
 }
 
 

--- a/Sources/JWTKeychain/Models/Users/User.swift
+++ b/Sources/JWTKeychain/Models/Users/User.swift
@@ -114,7 +114,7 @@ extension User {
 
             let token = try JWT(token: credentials.string)
 
-            if let userId = token.payload["id"]?.string {
+            if let userId = token.payload["user"]?.object?["id"]?.int {
                 user = try User.query().filter("id", userId).first()
             }
 

--- a/Sources/JWTKeychain/Models/Users/User.swift
+++ b/Sources/JWTKeychain/Models/Users/User.swift
@@ -114,7 +114,7 @@ extension User {
 
             let token = try JWT(token: credentials.string)
 
-            if let userId = token.payload["user"]?.object?["id"]?.int {
+            if let userId =  token.payload["user"]?.object?["id"]?.int {
                 user = try User.query().filter("id", userId).first()
             }
 

--- a/Sources/JWTKeychain/Models/Users/User.swift
+++ b/Sources/JWTKeychain/Models/Users/User.swift
@@ -114,7 +114,7 @@ extension User {
 
             let token = try JWT(token: credentials.string)
 
-            if let userId = token.payload[SubjectClaim.name]?.string {
+            if let userId = token.payload["id"]?.string {
                 user = try User.query().filter("id", userId).first()
             }
 

--- a/Sources/JWTKeychain/Models/Users/UserType.swift
+++ b/Sources/JWTKeychain/Models/Users/UserType.swift
@@ -26,4 +26,11 @@ public protocol UserType: Auth.User {
     /// - Returns: User in JSON format.
     /// - Throws: On transformation issue.
     func makeJSON(token: String) throws -> JSON
+
+    /// Creates a Node specifically for the 
+    /// JWT token
+    ///
+    /// - Returns: Node
+    /// - Throws: cannot create Node
+    func makeJWTNode() throws -> Node
 }

--- a/Sources/JWTKeychain/Requests/Api/Users/ResetPasswordRequest.swift
+++ b/Sources/JWTKeychain/Requests/Api/Users/ResetPasswordRequest.swift
@@ -1,0 +1,28 @@
+import Vapor
+import HTTP
+import VaporForms
+
+/// Handles the validation of resetting password
+class ResetPasswordRequest: Form {
+
+    let token: String
+    let email: String
+    let password: String
+    let passwordConfirmation: String
+
+    static let fieldset = Fieldset([
+        "email": StringField(String.EmailValidator()),
+        "password": StringField(String.MinimumLengthValidator(characters: 6), RegexValidator(regex: "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])")),
+        "password_confirmation": StringField(String.MinimumLengthValidator(characters: 6), RegexValidator(regex: "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])")),
+        ], requiring: ["token", "email", "password", "password_confirmation"])
+
+
+    required init(validatedData: [String: Node]) throws {
+        // validatedData is guaranteed to contain correct field names and values.
+        self.token = validatedData["token"]!.string!
+        self.email = validatedData["email"]!.string!
+        self.password = validatedData["password"]!.string!
+        self.passwordConfirmation = validatedData["password_confirmation"]!.string!
+    }
+
+}

--- a/Sources/JWTKeychain/Resources/Views/Emails/reset-password.leaf
+++ b/Sources/JWTKeychain/Resources/Views/Emails/reset-password.leaf
@@ -1,0 +1,20 @@
+<html>
+    <head>
+        <title>Reset password</title>
+    </head>
+    
+    <body>
+        <h4>Hello,</h4>
+        <p>
+        We have received a request to reset the password of the user with this e-mail.<br>
+        If you did not request this, simply ignore and delete this e-mail.
+        </p>
+        <p>
+        To reset your password, click the following link:<br>
+        <a href="#(url)/api/v1/users/reset/#(token)">#(url)/api/v1/users/reset/#(token)</a>
+        </p>
+	#if(expire > 0) { 
+       	    <p><em>This reset password request will expire in #(expire) minutes.</em></p>
+	}
+    </body>
+</html>

--- a/Sources/JWTKeychain/Resources/Views/Emails/reset-password.leaf
+++ b/Sources/JWTKeychain/Resources/Views/Emails/reset-password.leaf
@@ -11,7 +11,7 @@
         </p>
         <p>
         To reset your password, click the following link:<br>
-        <a href="#(url)/api/v1/users/reset/#(token)">#(url)/api/v1/users/reset/#(token)</a>
+        <a href="#(url)/api/v1/users/reset-password/form/#(token)">#(url)/api/v1/users/reset-password/form/#(token)</a>
         </p>
 	#if(expire > 0) { 
        	    <p><em>This reset password request will expire in #(expire) minutes.</em></p>

--- a/Sources/JWTKeychain/Resources/Views/Emails/reset-password.leaf
+++ b/Sources/JWTKeychain/Resources/Views/Emails/reset-password.leaf
@@ -11,9 +11,18 @@
         </p>
         <p>
         To reset your password, click the following link:<br>
-        <a href="#(url)/api/v1/users/reset-password/form/#(token)">#(url)/api/v1/users/reset-password/form/#(token)</a>
+        <a href="#(url)/api/v1/users/reset-password/form/#(token)">Reset Password</a>
         </p>
-	#if(expire > 0) { 
+
+        <br>
+        <br>
+        <p>
+            If you can't use the click above, please copy paste the following into your browser:
+            <br>
+            #(url)/api/v1/users/reset-password/form/#(token)
+        </p>
+
+	#if(expire > 0) {
        	    <p><em>This reset password request will expire in #(expire) minutes.</em></p>
 	}
     </body>

--- a/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
+++ b/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
@@ -56,7 +56,7 @@
         }
 
         <form method="POST" action="/api/v1/users/reset-password/change">
-            <input type="hidden" name="token" value="#(token.token)">
+            <input type="hidden" name="token" value="#(token)">
             <div class="form-group action-wrapper">
                 <label for="email">E-mail</label>
                 <input type="email" id="email" class="form-control" name="email" required placeholder="Insert email"/>

--- a/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
+++ b/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
@@ -59,19 +59,29 @@
             <input type="hidden" name="token" value="#(token)">
             <div class="form-group action-wrapper">
                 <label for="email">E-mail</label>
-                <input type="email" id="email" class="form-control" name="email" required placeholder="Insert email"/>
+                <input type="email" id="email" class="form-control" name="email" required placeholder="Insert email" 
+                value='#valueForField(fieldset, "email")'/>
+                #ifFieldHasErrors(fieldset, "email") { <ul class="errorlist"> }
+                #loopErrorsForField(fieldset, "email", "message") { <li>#(message)</li> }
+                #ifFieldHasErrors(fieldset, "email") { </ul> }
             </div>
 
             <div class="form-group">
                 <label for="password">New password</label>
                 <input type="password" id="password" class="form-control" name="password" required
                        placeholder="Insert password"/>
+                #ifFieldHasErrors(fieldset, "password") { <ul class="errorlist"> }
+                #loopErrorsForField(fieldset, "password", "message") { <li>#(message)</li> }
+                #ifFieldHasErrors(fieldset, "password") { </ul> }
             </div>
 
             <div class="form-group">
                 <label for="password_confirmation">New password confirmation</label>
                 <input type="password" id="password_confirmation" class="form-control" name="password_confirmation" required
                        placeholder="Insert password"/>
+                #ifFieldHasErrors(fieldset, "password_confirmation") { <ul class="errorlist"> }
+                #loopErrorsForField(fieldset, "password_confirmation", "message") { <li>#(message)</li> }
+                #ifFieldHasErrors(fieldset, "password_confirmation") { </ul> }
             </div>
 
             <div class="form-group">

--- a/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
+++ b/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
@@ -6,89 +6,94 @@
 </head>
 
 <body>
-<div id="login" class="panel panel-default">
-    <div class="panel-body">
+    <div class="row">
+        <div class="col-xs-12 col-sm-offset-4 col-sm-4">
+        
+            <div id="reset-password" class="panel panel-default">
+                <div class="panel-body">
+                    <div class="panel-heading">
+                        <h3 class="panel-title text-center">Reset password</h3>
+                    </div>
 
-        <div class="panel-heading">
-            <h3 class="panel-title text-center">Reset password</h3>
-        </div>
+                    <!--Error-->
+                    #if(request.storage._flash.error) {
+                    <div class="alert alert-danger alert-dismissible fade in to-be-animated-in" role="alert">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        <span class="fa fa-exclamation-circle"></span>
+                        #(request.storage._flash.error)
+                    </div>
+                    }
 
-        <!--Error-->
-        #if(request.storage._flash.error) {
-        <div class="alert alert-danger alert-dismissible fade in to-be-animated-in" role="alert">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-            <span class="fa fa-exclamation-circle"></span>
-            #(request.storage._flash.error)
-        </div>
-        }
+                    <!--Success-->
+                    #if(request.storage._flash.success) {
+                    <div class="alert alert-success alert-dismissible fade in to-be-animated-in" role="alert">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        <span class="fa fa-check-circle"></span>
+                        #(request.storage._flash.success)
+                    </div>
+                    }
 
-        <!--Success-->
-        #if(request.storage._flash.success) {
-        <div class="alert alert-success alert-dismissible fade in to-be-animated-in" role="alert">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-            <span class="fa fa-check-circle"></span>
-            #(request.storage._flash.success)
-        </div>
-        }
+                    <!--Warning-->
+                    #if(request.storage._flash.warning) {
+                    <div class="alert alert-warning alert-dismissible fade in to-be-animated-in" role="alert">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        #(request.storage._flash.warning)
+                    </div>
+                    }
 
-        <!--Warning-->
-        #if(request.storage._flash.warning) {
-        <div class="alert alert-warning alert-dismissible fade in to-be-animated-in" role="alert">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-            #(request.storage._flash.warning)
-        </div>
-        }
+                    <!--Info-->
+                    #if(request.storage._flash.info) {
+                    <div class="alert alert-info alert-dismissible fade in to-be-animated-in" role="alert">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        #(request.storage._flash.info)
+                    </div>
+                    }
+            
+                    <form method="POST" action="/api/v1/users/reset-password/change">
+                        <input type="hidden" name="token" value="#(token)">
+                
+                        <div class="form-group action-wrapper">
+                            <label for="email">E-mail</label>
+                            <input type="email" id="email" class="form-control" name="email" required placeholder="Insert email" 
+                                value='#valueForField(fieldset, "email")'/>
+                                #ifFieldHasErrors(fieldset, "email") { <ul class="errorlist"> }
+                                #loopErrorsForField(fieldset, "email", "message") { <li>#(message)</li> }
+                                #ifFieldHasErrors(fieldset, "email") { </ul> }
+                        </div>
 
-        <!--Info-->
-        #if(request.storage._flash.info) {
-        <div class="alert alert-info alert-dismissible fade in to-be-animated-in" role="alert">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-            #(request.storage._flash.info)
-        </div>
-        }
+                        <div class="form-group">
+                            <label for="password">New password</label>
+                            <input type="password" id="password" class="form-control" name="password" required
+                                   placeholder="Insert password"/>
+                            #ifFieldHasErrors(fieldset, "password") { <ul class="errorlist"> }
+                            #loopErrorsForField(fieldset, "password", "message") { <li>#(message)</li> }
+                            #ifFieldHasErrors(fieldset, "password") { </ul> }
+                        </div>
 
-        <form method="POST" action="/api/v1/users/reset-password/change">
-            <input type="hidden" name="token" value="#(token)">
-            <div class="form-group action-wrapper">
-                <label for="email">E-mail</label>
-                <input type="email" id="email" class="form-control" name="email" required placeholder="Insert email" 
-                value='#valueForField(fieldset, "email")'/>
-                #ifFieldHasErrors(fieldset, "email") { <ul class="errorlist"> }
-                #loopErrorsForField(fieldset, "email", "message") { <li>#(message)</li> }
-                #ifFieldHasErrors(fieldset, "email") { </ul> }
+                        <div class="form-group">
+                            <label for="password_confirmation">New password confirmation</label>
+                            <input type="password" id="password_confirmation" class="form-control" name="password_confirmation" required
+                                   placeholder="Insert password"/>
+                            #ifFieldHasErrors(fieldset, "password_confirmation") { <ul class="errorlist"> }
+                            #loopErrorsForField(fieldset, "password_confirmation", "message") { <li>#(message)</li> }
+                            #ifFieldHasErrors(fieldset, "password_confirmation") { </ul> }
+                        </div>
+
+                        <div class="form-group">
+                            <input type="submit" class="btn btn-primary form-control" value="Reset password"/>
+                        </div>
+                    </form>
+                </div>
             </div>
-
-            <div class="form-group">
-                <label for="password">New password</label>
-                <input type="password" id="password" class="form-control" name="password" required
-                       placeholder="Insert password"/>
-                #ifFieldHasErrors(fieldset, "password") { <ul class="errorlist"> }
-                #loopErrorsForField(fieldset, "password", "message") { <li>#(message)</li> }
-                #ifFieldHasErrors(fieldset, "password") { </ul> }
-            </div>
-
-            <div class="form-group">
-                <label for="password_confirmation">New password confirmation</label>
-                <input type="password" id="password_confirmation" class="form-control" name="password_confirmation" required
-                       placeholder="Insert password"/>
-                #ifFieldHasErrors(fieldset, "password_confirmation") { <ul class="errorlist"> }
-                #loopErrorsForField(fieldset, "password_confirmation", "message") { <li>#(message)</li> }
-                #ifFieldHasErrors(fieldset, "password_confirmation") { </ul> }
-            </div>
-
-            <div class="form-group">
-                <input type="submit" class="btn btn-primary form-control" value="Reset password"/>
-            </div>
-        </form>
+        </div>
     </div>
-</div>
 </body>
 </html>

--- a/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
+++ b/Sources/JWTKeychain/Resources/Views/ResetPassword/form.leaf
@@ -1,0 +1,84 @@
+<html>
+<head>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+</head>
+
+<body>
+<div id="login" class="panel panel-default">
+    <div class="panel-body">
+
+        <div class="panel-heading">
+            <h3 class="panel-title text-center">Reset password</h3>
+        </div>
+
+        <!--Error-->
+        #if(request.storage._flash.error) {
+        <div class="alert alert-danger alert-dismissible fade in to-be-animated-in" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <span class="fa fa-exclamation-circle"></span>
+            #(request.storage._flash.error)
+        </div>
+        }
+
+        <!--Success-->
+        #if(request.storage._flash.success) {
+        <div class="alert alert-success alert-dismissible fade in to-be-animated-in" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <span class="fa fa-check-circle"></span>
+            #(request.storage._flash.success)
+        </div>
+        }
+
+        <!--Warning-->
+        #if(request.storage._flash.warning) {
+        <div class="alert alert-warning alert-dismissible fade in to-be-animated-in" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            #(request.storage._flash.warning)
+        </div>
+        }
+
+        <!--Info-->
+        #if(request.storage._flash.info) {
+        <div class="alert alert-info alert-dismissible fade in to-be-animated-in" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            #(request.storage._flash.info)
+        </div>
+        }
+
+        <form method="POST" action="/api/v1/users/reset-password/change">
+            <input type="hidden" name="token" value="#(token.token)">
+            <div class="form-group action-wrapper">
+                <label for="email">E-mail</label>
+                <input type="email" id="email" class="form-control" name="email" required placeholder="Insert email"/>
+            </div>
+
+            <div class="form-group">
+                <label for="password">New password</label>
+                <input type="password" id="password" class="form-control" name="password" required
+                       placeholder="Insert password"/>
+            </div>
+
+            <div class="form-group">
+                <label for="password_confirmation">New password confirmation</label>
+                <input type="password" id="password_confirmation" class="form-control" name="password_confirmation" required
+                       placeholder="Insert password"/>
+            </div>
+
+            <div class="form-group">
+                <input type="submit" class="btn btn-primary form-control" value="Reset password"/>
+            </div>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/Sources/JWTKeychain/Routes/Frontend/FrontendResetPasswordRoutes.swift
+++ b/Sources/JWTKeychain/Routes/Frontend/FrontendResetPasswordRoutes.swift
@@ -1,0 +1,53 @@
+import Vapor
+import Auth
+import Routing
+import HTTP
+
+/// Defines basic reset password routes.
+public struct FrontendResetPasswordRoutes: RouteCollection {
+    public typealias Wrapped = Responder
+
+    private let drop: Droplet
+    private let configuration: ConfigurationType!
+    private let controller: FrontendResetPasswordControllerType!
+
+    /// Initializes the user route collection.
+    ///
+    /// - Parameters:
+    ///   - drop: the droplet reference.
+    ///   - configuration: configuration for JWT.
+    ///     Defaults to `Configuration`.
+    ///   - jwtAuthMiddleware: middleware for JWT authentication.
+    ///     Defaults to `JWT.AuthMiddleware`.
+    ///   - authMiddleware: authentication middleware.
+    ///     Defaults to `Auth.AuthMiddleware`.
+    ///   - protectMiddleware: protect middleware for protected routes.
+    ///     Defaults to `ProtectMiddleware`.
+    ///   - userController: controller for handling user routes.
+    ///     Defaults to `UserController`.
+    /// - Throws: if configuration cannot be created.
+    public init(
+        drop: Droplet,
+        configuration: ConfigurationType? = nil,
+        resetPasswordController: FrontendResetPasswordControllerType? = nil
+        ) throws {
+
+        self.drop = drop
+        let config = try configuration ?? Configuration(drop: drop)
+        self.configuration = config
+        self.controller = resetPasswordController ?? FrontendResetPasswordController(drop: drop, configuration: config)
+
+    }
+
+    public func build<Builder: RouteBuilder>(
+        _ builder: Builder
+        ) where Builder.Value == Responder {
+
+        // Get the base path group
+        builder.group("reset-password") { routes in
+            routes.get("form", String.self, handler: controller.resetPasswordForm)
+            routes.post("change", handler: controller.resetPasswordChange)
+        }
+
+    }
+}

--- a/Sources/JWTKeychain/Routes/UserRoutes.swift
+++ b/Sources/JWTKeychain/Routes/UserRoutes.swift
@@ -69,7 +69,7 @@ public struct UserRoutes: RouteCollection {
         }
 
         // Protected routes
-        path.group(jwtAuthMiddleware, authMiddleware, protectMiddleware) { secured in
+        path.group(authMiddleware, jwtAuthMiddleware,  protectMiddleware) { secured in
             secured.get("logout", handler: controller.logout)
             secured.patch("token", "regenerate", handler: controller.regenerate)
             secured.get("me", handler: controller.me)

--- a/Sources/JWTKeychain/Routes/UserRoutes.swift
+++ b/Sources/JWTKeychain/Routes/UserRoutes.swift
@@ -36,7 +36,10 @@ public struct UserRoutes: RouteCollection {
     ) where Builder.Value == Responder {
 
         // Define the controller
-        let controller = UsersController(configuration: self.configuration)
+        let controller = UsersController(
+            configuration: self.configuration,
+            drop: self.drop
+        )
 
         // Get the base path group
         let path = builder.grouped("users")

--- a/Sources/JWTKeychain/Routes/UserRoutes.swift
+++ b/Sources/JWTKeychain/Routes/UserRoutes.swift
@@ -63,6 +63,9 @@ public struct UserRoutes: RouteCollection {
         path.group(authMiddleware) { jwtRoutes in
             jwtRoutes.post(handler: controller.register)
             jwtRoutes.post("login", handler: controller.login)
+            jwtRoutes.post("reset-password", "request", handler: controller.resetPasswordEmail)
+            jwtRoutes.get("reset-password", "form", String.self, handler: controller.resetPasswordForm)
+            jwtRoutes.post("reset-password", "change", handler: controller.resetPasswordChange)
         }
 
         // Protected routes

--- a/Sources/JWTKeychain/Routes/UserRoutes.swift
+++ b/Sources/JWTKeychain/Routes/UserRoutes.swift
@@ -49,7 +49,7 @@ public struct UserRoutes: RouteCollection {
         self.jwtAuthMiddleware = jwtAuthMiddleware ?? JWTKeychain.AuthMiddleware(configuration: config)
         self.authMiddleware = authMiddleware
         self.protectMiddleware = protectMiddleware
-        self.controller = userController ?? UserController(configuration: config)
+        self.controller = userController ?? UserController(configuration: config, drop: drop)
     }
 
     public func build<Builder: RouteBuilder>(

--- a/Sources/JWTKeychain/Support/Claims/UserClaim.swift
+++ b/Sources/JWTKeychain/Support/Claims/UserClaim.swift
@@ -1,0 +1,26 @@
+import Node
+import VaporJWT
+
+public struct UserClaim: Claim {
+    public static var name = "user"
+
+    public let value: Node
+
+    public var node: Node
+
+    public init(_ value: Node) {
+        self.value = value
+        self.node = value
+    }
+
+    public func verify(_ node: Node) -> Bool {
+
+        if let _ = node.object?["id"]?.int {
+            return true
+        }
+
+        return false
+
+    }
+
+}

--- a/Sources/JWTKeychain/Support/Configuration/Configuration.swift
+++ b/Sources/JWTKeychain/Support/Configuration/Configuration.swift
@@ -220,7 +220,7 @@ public struct Configuration: ConfigurationType {
         var contents: [Node] = []
 
         // Add the user Node
-        contents.append(userInfo)
+        contents.append(Node(["user": userInfo]))
 
         // Add the claims as Nodes
         for claim in claims {

--- a/Sources/JWTKeychain/Support/Configuration/Configuration.swift
+++ b/Sources/JWTKeychain/Support/Configuration/Configuration.swift
@@ -196,9 +196,6 @@ public struct Configuration: ConfigurationType {
     /// - Returns: string with valid JWT token
     public func generateToken(user: UserType, extraClaims: Claim...) throws -> String {
 
-        // Prepare payload Node
-        var payload: Node
-
         // Extract user info into Node
         let userInfo = try user.makeNode()
 
@@ -216,22 +213,14 @@ public struct Configuration: ConfigurationType {
         // Add the claims passed into the method
         claims.append(contentsOf: extraClaims)
 
-        // Prepare contents for payload
-        var contents: [Node] = []
+        // Add user info
+        claims.append(UserClaim(userInfo))
 
-        // Add the user Node
-        contents.append(Node(["user": userInfo]))
+        let claimNode = Node(claims)
 
-        // Add the claims as Nodes
-        for claim in claims {
-            contents.append(claim.node)
-        }
-        
-        payload = Node(contents)
-        
         // Generate our Token
         let jwt = try JWT(
-            payload: payload,
+            payload: claimNode,
             signer: self.getSigner(key: self.signatureKeyBytes)
         )
         

--- a/Sources/JWTKeychain/Support/Configuration/Configuration.swift
+++ b/Sources/JWTKeychain/Support/Configuration/Configuration.swift
@@ -7,9 +7,37 @@ import Auth
 /// Sets the protocol of what is expected on the config file
 public protocol ConfigurationType {
 
+    /// Validates a given token
+    ///
+    /// - Parameter token: string with the token
+    /// - Returns: true if token is valid, else false
+    /// - Throws: if unable to create JWT instance
     func validateToken(token: String) throws -> Bool
+
+    /// Generates a token for the user
+    /// - Parameter: userId is used to create a SubjectClaim
+    /// - Parameter: extraClaims are optional customized claims
+    /// - Returns: string with valid JWT token
     func generateToken(user: UserType, extraClaims: Claim...) throws -> String
+
+    /// Generates the reset password token with the settings provided on the
+    /// config
+    ///
+    /// - Parameter user: user to generate the token
+    /// - Returns: token string
+    /// - Throws: not able to generate token
     func generateResetPasswordToken(user: UserType) throws -> String
+
+    /// Returns the path to the reset password view
+    ///
+    /// - Returns: path
+    func getResetPasswordEmaiView() -> String
+
+    /// Returns number of seconds that the token will expire in
+    ///
+    /// - Returns: seconds
+    func getResetPasswordTokenExpirationTime() -> Double
+
 }
 
 public struct Configuration: ConfigurationType {
@@ -27,7 +55,7 @@ public struct Configuration: ConfigurationType {
     private var signer: String
 
     /// The path to the reset password email
-    private var resetPasswordEmail: String
+    public var resetPasswordEmail: String
 
     /// Seconds the reset password token has to expire (in the future)
     private var secondsToExpireResetPassword: Double
@@ -145,12 +173,6 @@ public struct Configuration: ConfigurationType {
 
     }
 
-
-    /// Validates a given token
-    ///
-    /// - Parameter token: string with the token
-    /// - Returns: true if token is valid, else false
-    /// - Throws: if unable to create JWT instance
     public func validateToken(token: String) throws -> Bool {
 
         do {
@@ -190,10 +212,6 @@ public struct Configuration: ConfigurationType {
         return false
     }
 
-    /// Generates a token for the user
-    /// - Parameter: userId is used to create a SubjectClaim
-    /// - Parameter: extraClaims are optional customized claims
-    /// - Returns: string with valid JWT token
     public func generateToken(user: UserType, extraClaims: Claim...) throws -> String {
 
         // Extract user info into Node
@@ -226,21 +244,21 @@ public struct Configuration: ConfigurationType {
         
         // Return the token string
         return try jwt.createToken()
-        
     }
 
-    /// Generates the reset password token with the settings provided on the 
-    /// config
-    ///
-    /// - Parameter user: user to generate the token
-    /// - Returns: token string
-    /// - Throws: not able to generate token
     public func generateResetPasswordToken(user: UserType) throws -> String {
 
         // Make a token that expires in
         let expiryClaim = ExpirationTimeClaim(Date() + self.secondsToExpireResetPassword)
         return try self.generateToken(user: user, extraClaims: expiryClaim)
+    }
 
+    public func getResetPasswordEmaiView() -> String {
+        return self.resetPasswordEmail
+    }
+
+    public func getResetPasswordTokenExpirationTime() -> Double {
+        return self.secondsToExpireResetPassword
     }
     
 }

--- a/Sources/JWTKeychain/Support/Configuration/Configuration.swift
+++ b/Sources/JWTKeychain/Support/Configuration/Configuration.swift
@@ -197,7 +197,7 @@ public struct Configuration: ConfigurationType {
     public func generateToken(user: UserType, extraClaims: Claim...) throws -> String {
 
         // Extract user info into Node
-        let userInfo = try user.makeNode()
+        let userInfo = try user.makeJWTNode()
 
         // Prepare claims
         var claims: [Claim] = []

--- a/Sources/JWTKeychain/Support/Mailer.swift
+++ b/Sources/JWTKeychain/Support/Mailer.swift
@@ -49,7 +49,6 @@ public class Mailer {
             ]
             ).data.string()
 
-
         let email: SMTP.Email = Email(
             from: from,
             to: user.email,
@@ -62,7 +61,7 @@ public class Mailer {
             port: smtpPort,
             securityLayer: SecurityLayer.tls(nil)
         )
-
+        
         try client.send(email, using: credentials)
     }
 }

--- a/Sources/JWTKeychain/Support/Mailer.swift
+++ b/Sources/JWTKeychain/Support/Mailer.swift
@@ -1,0 +1,68 @@
+import Vapor
+import SMTP
+import Transport
+
+public class Mailer {
+
+    /// Sends an email to the user with the password reset URL
+    ///
+    /// - Parameters:
+    ///   - drop: droplet
+    ///   - user: user that is resetting the password
+    ///   - token: JWT token generated to identify the user
+    ///   - resetPasswordEmail: the path to the email view
+    ///   - expires: how much time the token will be valid (in minutes)
+    /// - Throws: if essential configs are not present
+    public static func sendResetPasswordMail(drop: Droplet, user: User, token: String, resetPasswordEmail: String? = nil, expires: Int? = nil) throws {
+
+        guard let smtpUser = drop.config["mail", "user"]?.string,
+            let smtpPassword = drop.config["mail", "password"]?.string,
+            let fromEmail = drop.config["mail", "fromEmail"]?.string,
+            let fromName = drop.config["mail", "fromName"]?.string,
+            let smtpHost = drop.config["mail", "smtpHost"]?.string,
+            let smtpPort = drop.config["mail", "smtpPort"]?.int,
+            let appUrl = drop.config["app", "url"]?.string,
+            let appName = drop.config["app", "name"]?.string
+            else {
+                throw Abort.custom(
+                    status: .internalServerError,
+                    message: "Settings required to send email are not set. Please check mail.json (user, password, fromEmail, smtpHost, smtpPort) and app.json (name, url)."
+                )
+        }
+
+        let credentials = SMTPCredentials(
+            user: smtpUser,
+            pass: smtpPassword
+        )
+
+        let from = EmailAddress(name: fromName, address: fromEmail)
+
+        // Generate HTML
+        let html = try drop.view.make(
+            resetPasswordEmail ?? "Emails/reset-password",
+            [
+                "name": appName,
+                "user": user.makeNode(),
+                "token": token,
+                "expire": expires ?? 0,
+                "url": appUrl
+            ]
+            ).data.string()
+
+
+        let email: SMTP.Email = Email(
+            from: from,
+            to: user.email,
+            subject: "Reset password",
+            body: EmailBody(type: .html, content: html)
+        )
+
+        let client = try SMTPClient<TCPClientStream>(
+            host: smtpHost,
+            port: smtpPort,
+            securityLayer: SecurityLayer.tls(nil)
+        )
+
+        try client.send(email, using: credentials)
+    }
+}

--- a/Sources/JWTKeychain/Support/MailerType.swift
+++ b/Sources/JWTKeychain/Support/MailerType.swift
@@ -1,0 +1,20 @@
+import Vapor
+
+/// Defines basic email functionality.
+public protocol MailerType {
+
+    /// Initializes the Mailer with the JWT configuration.
+    ///
+    /// - Parameters:
+    /// configuration : the JWT configuration.
+    /// drop : the Droplet instance
+    init(configuration: ConfigurationType, drop: Droplet)
+
+    /// Sends an email to the user with the password reset URL
+    ///
+    /// - Parameters:
+    ///   - user: user that is resetting the password
+    ///   - token: JWT token generated to identify the user
+    /// - Throws: if essential configs are not present
+    func sendResetPasswordMail(user: UserType, token: String, subject: String) throws
+}

--- a/Sources/JWTKeychain/Validators/ExistsFieldValidator.swift
+++ b/Sources/JWTKeychain/Validators/ExistsFieldValidator.swift
@@ -44,7 +44,7 @@ public class ExistsFieldValidator<ModelType: Entity>: FieldValidator<String> {
 
             // Check if any record exists
             if(try query.count() < 1){
-                return .failure([.validationFailed(message: message ?? "\(self.column) is does not exist")])
+                return .failure([.validationFailed(message: message ?? "\(self.column) \(value) does not exist")])
             }
 
             // If not we have green light
@@ -52,7 +52,7 @@ public class ExistsFieldValidator<ModelType: Entity>: FieldValidator<String> {
 
 
         } catch {
-            return .failure([.validationFailed(message: message ?? "\(self.column) is does not exist")])
+            return .failure([.validationFailed(message: message ?? "\(self.column) \(value) does not exist")])
         }
     }
 }

--- a/Sources/JWTKeychain/Validators/ExistsFieldValidator.swift
+++ b/Sources/JWTKeychain/Validators/ExistsFieldValidator.swift
@@ -3,23 +3,23 @@ import VaporForms
 import Fluent
 
 /// Validates if the value exists on the database
-public class UniqueFieldValidator<ModelType: Entity>: FieldValidator<String> {
-    
+public class ExistsFieldValidator<ModelType: Entity>: FieldValidator<String> {
+
     let column: String
     var additionalFilters: [(column:String, comparison:Filter.Comparison, value:String)] = []
     let message: String?
-    
+
     public init(column: String, additionalFilters: [(column:String, comparison:Filter.Comparison, value:String)]=[], message: String?=nil) {
-        
+
         self.column = column
         self.additionalFilters.append(contentsOf: additionalFilters)
         self.message = message
-        
+
     }
 
     public convenience init(column: String, ignoreColumn: String, ignoreValue: String,
-                            additionalFilters: [(column:String, comparison:Filter.Comparison, value:String)]=[],
-                            message: String?=nil) {
+        additionalFilters: [(column:String, comparison:Filter.Comparison, value:String)]=[],
+        message: String?=nil) {
 
         let ignoreFilter = (column: ignoreColumn, comparison: Filter.Comparison.notEquals, value: ignoreValue)
 
@@ -28,31 +28,31 @@ public class UniqueFieldValidator<ModelType: Entity>: FieldValidator<String> {
 
         self.init(column: column, additionalFilters: additionalFilters, message: message)
     }
-    
+
     public override func validate(input value: String) -> FieldValidationResult {
-        
+
         // Let's create the main filter
         do {
             let query = try ModelType.query()
-            
+
             try query.filter(self.column, value)
-            
+
             // If we have addition filters, add them
-            try self.additionalFilters.forEach({filter in
+            try self.additionalFilters.forEach({ filter in
                 try query.filter(filter.column, filter.comparison, filter.value)
             })
-            
+
             // Check if any record exists
-            if(try query.count() > 0){
-                return .failure([.validationFailed(message: message ?? "\(self.column) is not unique")])
+            if(try query.count() < 1){
+                return .failure([.validationFailed(message: message ?? "\(self.column) is does not exist")])
             }
-            
+
             // If not we have green light
             return .success(Node(value))
-            
-            
+
+
         } catch {
-            return .failure([.validationFailed(message: message ?? "\(self.column) is not unique")])
+            return .failure([.validationFailed(message: message ?? "\(self.column) is does not exist")])
         }
     }
 }

--- a/Tests/JWTKeychainTests/Middleware/AuthMiddlewareTests.swift
+++ b/Tests/JWTKeychainTests/Middleware/AuthMiddlewareTests.swift
@@ -18,7 +18,7 @@ class AuthMiddlewareTests: XCTestCase {
 
     override func setUp() {
       
-          self.configuration = JWTKeychain.Configuration(signer: "HS256", signatureKey: "key", publicKey: nil, secondsToExpire: 0)
+          self.configuration = JWTKeychain.Configuration(signer: "HS256", signatureKey: "key", publicKey: nil, secondsToExpire: 0, resetPasswordEmail: "Emails/reset-password", secondsToExpireResetPassword: 3600)
 
           self.middleware = JWTKeychain.AuthMiddleware(configuration: self.configuration!)
 
@@ -83,7 +83,7 @@ class AuthMiddlewareTests: XCTestCase {
 
         let req = try? Request(method: .get, uri: "api/v1/users/me")
 
-        let token = try self.configuration!.generateToken(user: user.id!)
+        let token = try self.configuration!.generateToken(user: user)
 
         req?.headers["Authorization"] = "Bearer " + token
 

--- a/Tests/JWTKeychainTests/Middleware/AuthMiddlewareTests.swift
+++ b/Tests/JWTKeychainTests/Middleware/AuthMiddlewareTests.swift
@@ -18,7 +18,7 @@ class AuthMiddlewareTests: XCTestCase {
 
     override func setUp() {
       
-          self.configuration = Configuration(signer: "HS256", signatureKey: "key", publicKey: nil, secondsToExpire: 0)
+          self.configuration = JWTKeychain.Configuration(signer: "HS256", signatureKey: "key", publicKey: nil, secondsToExpire: 0)
 
           self.middleware = JWTKeychain.AuthMiddleware(configuration: self.configuration!)
 
@@ -83,7 +83,7 @@ class AuthMiddlewareTests: XCTestCase {
 
         let req = try? Request(method: .get, uri: "api/v1/users/me")
 
-        let token = try self.configuration!.generateToken(userId: user.id!)
+        let token = try self.configuration!.generateToken(user: user.id!)
 
         req?.headers["Authorization"] = "Bearer " + token
 


### PR DESCRIPTION
- Included routes for password reset;
- Included email and form for password reset;
- Created a UserClaim to be able to add user info to the JWT payload;
- Added a new method to the UserType called makeJWTNode() where you can configure what user info you want on the JWT payload;
- Changed vapor-forms to use the original package;