### PR TITLE
Opened up configuration.

### DIFF
--- a/Sources/JWTKeychain/Controllers/API/UserController.swift
+++ b/Sources/JWTKeychain/Controllers/API/UserController.swift
@@ -9,7 +9,7 @@ import VaporForms
 
 /// Basic controller functionality for a user than can be authorized.
 open class UserController: UserControllerType {
-    private let configuration: ConfigurationType
+    public let configuration: ConfigurationType
 
     required public init(configuration: ConfigurationType) {
         self.configuration = configuration


### PR DESCRIPTION
Our LinkedIn signer does login/registration completely independent of JWTKeychain and we need to be able to sign tokens without having to create a `Request` manually and looping back through all of the verification we just did.