### PR TITLE
Add flag to force authentication

### DIFF
--- a/Sources/JWTKeychain/Config/JWTKeychainConfig.swift
+++ b/Sources/JWTKeychain/Config/JWTKeychainConfig.swift
@@ -16,6 +16,9 @@ public struct JWTKeychainConfig: Service {
     /// Determines whether to register the routes for the `endpoints` at boot time.
     public let shouldRegisterRoutes: Bool
 
+    /// Determines whether to require authentication on all endpoints (access and refresh).
+    public let forceAuthentication: Bool
+
     /// Creates a new JWTKeychain configuration.
     ///
     /// - Parameters:
@@ -25,15 +28,18 @@ public struct JWTKeychainConfig: Service {
     ///   - endpoints: determines the endpoints for the routes
     ///   - shouldRegisterRoutes: determines whether to register the routes for the `endpoints` at
     ///     boot time.
+    ///   - forceAuthentication: determines whether to require authentication on all endpoints (access and refresh).
     public init(
         accessTokenSigner: ExpireableJWTSigner,
         refreshTokenSigner: ExpireableJWTSigner? = nil,
         endpoints: JWTKeychainEndpoints = .default,
-        shouldRegisterRoutes: Bool = true
+        shouldRegisterRoutes: Bool = true,
+        forceAuthentication: Bool = true
     ) {
         self.accessTokenSigner = accessTokenSigner
         self.refreshTokenSigner = refreshTokenSigner
         self.endpoints = endpoints
         self.shouldRegisterRoutes = shouldRegisterRoutes
+        self.forceAuthentication = forceAuthentication
     }
 }

--- a/Sources/JWTKeychain/Provider/JWTKeychainProvider.swift
+++ b/Sources/JWTKeychain/Provider/JWTKeychainProvider.swift
@@ -23,11 +23,8 @@ public final class JWTKeychainProvider<U: JWTCustomPayloadKeychainUserType> {
             )
         ]
 
-        var refreshMiddlewares: [Middleware]?
-        if let refresh = config.refreshTokenSigner {
-            refreshMiddlewares = [
-                JWTAuthenticationMiddleware<U>(signer: refresh.signer)
-            ]
+        var refreshMiddlewares: [Middleware]? = config.refreshTokenSigner.map {
+            [JWTAuthenticationMiddleware<U>(signer: $0.signer)]
         }
 
         if config.forceAuthentication {


### PR DESCRIPTION
So it seems that the force-authentication-middleware already existed and was already used in the package. As discussed and agreed, this PR makes the JWT Keychain a bit more opinionated by adding this middleware automatically except if you opt out through the config (new field added).

This touches upon the discussion in https://github.com/nodes-vapor/sugar/pull/68 and this is a breaking change.