### PR TITLE
makes JWTKeychainUser conform to MySQLProtocol in Swift 5.2

### DIFF
--- a/Sources/JWTKeychain/Models/JWTKeychainUser/JWTKeychainUser.swift
+++ b/Sources/JWTKeychain/Models/JWTKeychainUser/JWTKeychainUser.swift
@@ -33,6 +33,7 @@ extension JWTKeychainUser: Content {}
 extension JWTKeychainUser: HasPassword {}
 extension JWTKeychainUser: Migration {}
 extension JWTKeychainUser: MySQLModel {
+    public typealias Database = MySQLDatabase
     public static let createdAtKey: TimestampKey? = \.createdAt
     public static let updatedAtKey: TimestampKey? = \.updatedAt
     public static let deletedAtKey: TimestampKey? = \.deletedAt


### PR DESCRIPTION
Hi

Now, I don't know if I'm completely misunderstanding the finer points of Vapor but I noticed that I can't get `jwt-keychain` to work with Xcode 11.4 because `JWTKeychainUser` no longer conforms to `MySQLModel` and `Migration` in Swift 5.2.

Adding 

> public typealias Database = MySQLDatabase

to `extension JWTKeychainUser: MySQLModel` fixes this but as I said I don't know if that misses some fine details I'm not aware of.

Apart from that, it puzzles me that upgrading from Swift 5.1 to 5.2 means that a class no longer conforms to a `protocol` internal to Vapor 😕 but 🤷 